### PR TITLE
Support returning wordEndIndex and retrieving count of nodes in trie

### DIFF
--- a/AhoCorasick.Tests.cs
+++ b/AhoCorasick.Tests.cs
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Linq;
 
 using NUnit.Framework;
@@ -36,11 +37,11 @@ namespace AhoCorasick
             trie.Add("world");
             trie.Build();
 
-            string[] matches = trie.Find(text).ToArray();
+            var matches = trie.Find(text).ToArray();
 
             Assert.AreEqual(2, matches.Length);
-            Assert.AreEqual("hello", matches[0]);
-            Assert.AreEqual("world", matches[1]);
+            Assert.AreEqual(new Tuple<string, int>("hello", 4), (Tuple<string, int>)matches[0]);
+            Assert.AreEqual(new Tuple<string, int>("world", 40), (Tuple<string, int>)matches[1]);
         }
 
         [Test]
@@ -57,21 +58,40 @@ namespace AhoCorasick
         }
 
         [Test]
-        public void LineNumbers()
+        public void Ids()
         {
-            string text = "world, i hello you!";
-            string[] words = new[] { "hello", "world" };
+            string text = "hello and welcome to this beautiful world!";
 
             AhoCorasick.Trie<int> trie = new AhoCorasick.Trie<int>();
-            for (int i = 0; i < words.Length; i++)
-                trie.Add(words[i], i);
+            trie.Add("hello", 123);
+            trie.Add("world", 456);
+
             trie.Build();
 
-            int[] lines = trie.Find(text).ToArray();
+            var matches = trie.Find(text).ToArray();
 
-            Assert.AreEqual(2, lines.Length);
-            Assert.AreEqual(1, lines[0]);
-            Assert.AreEqual(0, lines[1]);
+            Assert.AreEqual(2, matches.Length);
+            Assert.AreEqual(new Tuple<int, int>(123, 4), matches[0]);
+            Assert.AreEqual(new Tuple<int, int>(456, 40), matches[1]);
+        }
+
+        [Test]
+        public void WordsAndIds()
+        {
+            string text = "hello and welcome to this beautiful world!";
+
+            AhoCorasick.Trie<Tuple<string, int>> trie = new AhoCorasick.Trie<Tuple<string, int>>();
+
+            trie.Add("hello", new Tuple<string, int>("hello", 123));
+            trie.Add("world", new Tuple<string, int>("world", 456));
+
+            trie.Build();
+
+            var matches = trie.Find(text).ToArray();
+
+            Assert.AreEqual(2, matches.Length);
+            Assert.AreEqual(new Tuple<Tuple<string, int>, int>(new Tuple<string, int>("hello", 123), 4), matches[0]);
+            Assert.AreEqual(new Tuple<Tuple<string, int>, int>(new Tuple<string, int>("world", 456), 40), matches[1]);
         }
 
         [Test]

--- a/AhoCorasick.Tests.cs
+++ b/AhoCorasick.Tests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2013 Pēteris Ņikiforovs
+// Copyright (c) 2013 Pēteris Ņikiforovs
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,7 @@ namespace AhoCorasick
         {
             string text = "hello and welcome to this beautiful world!";
 
-            AhoCorasick.Trie trie = new AhoCorasick.Trie();
+            var trie = new AhoCorasick.Trie();
             trie.Add("hello");
             trie.Add("world");
             trie.Build();
@@ -40,8 +40,8 @@ namespace AhoCorasick
             var matches = trie.Find(text).ToArray();
 
             Assert.AreEqual(2, matches.Length);
-            Assert.AreEqual(new Tuple<string, int>("hello", 4), (Tuple<string, int>)matches[0]);
-            Assert.AreEqual(new Tuple<string, int>("world", 40), (Tuple<string, int>)matches[1]);
+            Assert.AreEqual(Tuple.Create("hello", 4), matches[0]);
+            Assert.AreEqual(Tuple.Create("world", 40), matches[1]);
         }
 
         [Test]
@@ -49,7 +49,7 @@ namespace AhoCorasick
         {
             string text = "hello and welcome to this beautiful world!";
 
-            AhoCorasick.Trie trie = new AhoCorasick.Trie();
+            var trie = new AhoCorasick.Trie();
             trie.Add("hello");
             trie.Add("world");
             trie.Build();
@@ -62,7 +62,7 @@ namespace AhoCorasick
         {
             string text = "hello and welcome to this beautiful world!";
 
-            AhoCorasick.Trie<int> trie = new AhoCorasick.Trie<int>();
+            var trie = new AhoCorasick.Trie<int>();
             trie.Add("hello", 123);
             trie.Add("world", 456);
 
@@ -71,8 +71,8 @@ namespace AhoCorasick
             var matches = trie.Find(text).ToArray();
 
             Assert.AreEqual(2, matches.Length);
-            Assert.AreEqual(new Tuple<int, int>(123, 4), matches[0]);
-            Assert.AreEqual(new Tuple<int, int>(456, 40), matches[1]);
+            Assert.AreEqual(Tuple.Create(123, 4), matches[0]);
+            Assert.AreEqual(Tuple.Create(456, 40), matches[1]);
         }
 
         [Test]
@@ -80,26 +80,26 @@ namespace AhoCorasick
         {
             string text = "hello and welcome to this beautiful world!";
 
-            AhoCorasick.Trie<Tuple<string, int>> trie = new AhoCorasick.Trie<Tuple<string, int>>();
+            var trie = new AhoCorasick.Trie<Tuple<string, int>>();
 
-            trie.Add("hello", new Tuple<string, int>("hello", 123));
-            trie.Add("world", new Tuple<string, int>("world", 456));
+            trie.Add("hello", Tuple.Create("hello", 123));
+            trie.Add("world", Tuple.Create("world", 456));
 
             trie.Build();
 
             var matches = trie.Find(text).ToArray();
 
             Assert.AreEqual(2, matches.Length);
-            Assert.AreEqual(new Tuple<Tuple<string, int>, int>(new Tuple<string, int>("hello", 123), 4), matches[0]);
-            Assert.AreEqual(new Tuple<Tuple<string, int>, int>(new Tuple<string, int>("world", 456), 40), matches[1]);
+            Assert.AreEqual(Tuple.Create(Tuple.Create("hello", 123), 4), matches[0]);
+            Assert.AreEqual(Tuple.Create(Tuple.Create("world", 456), 40), matches[1]);
         }
 
         [Test]
         public void Words()
         {
             string[] text = "one two three four".Split(' ');
-            
-            AhoCorasick.Trie<string, bool> trie = new AhoCorasick.Trie<string, bool>();
+
+            var trie = new AhoCorasick.Trie<string, bool>();
             trie.Add(new[] { "three", "four" }, true);
             trie.Build();
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,15 @@ trie.Build();
 
 string text = "hello and welcome to this beautiful world!";
 
-// find words
-foreach (string word in trie.Find(text)) {
-  Console.WriteLine(word);
+// find words and wordEndIndices
+foreach (Tuple<string, int> tuple in trie.Find(text)) {
+  var word = tuple.Item1;
+  var wordEndIndex = tuple.Item2;
+  Console.WriteLine("{0}, {1}", word, wordEndIndex);
 }
 ```
 
-You can associate other data with the words (like an ID or line number).
+You could associate other data with the words (like an ID or line number).
 
 ```csharp
 AhoCorasick.Trie<int> trie = new AhoCorasick.Trie<int>();
@@ -33,9 +35,34 @@ trie.Add("world", 456);
 // build search tree
 trie.Build();
 
-// retrieve IDs
-foreach (int id in trie.Find(text)) {
-  Console.WriteLine(id);
+// retrieve IDs and wordEndIndices
+foreach (Tuple<int, int> tuple in trie.Find(text))
+{
+  var id = tuple.Item1;
+  var wordEndIndex = tuple.Item2;
+  Console.WriteLine("{0}, {1}", id, wordEndIndex);
+}
+```
+
+You also could retrieve matched strings and associated data (like an ID or line number)
+
+```csharp
+AhoCorasick.Trie<Tuple<string, int>> trie = new AhoCorasick.Trie<int>();
+
+// add words
+trie.Add("hello", new Tuple<string, int>("hello", 123));
+trie.Add("world", new Tuple<string, int>("world", 456));
+
+// build search tree
+trie.Build();
+
+// find words, IDs and wordEndIndices
+foreach (Tuple<Tuple<string, int>, int> tuple in trie.Find(text))
+{
+  var word = tuple.Item1.Item1;
+  var id = tuple.Item1.Item2;
+  var wordEndIndex = tuple.Item2;
+  Console.WriteLine("{0}, {1}, {2}", word, id, wordEndIndex);
 }
 ```
 


### PR DESCRIPTION
New feature:
1. Support to retrieve the number of nodes added in trie.
2. Support to return wordEndIndex of text in matching stage.

Update Unit Tests for
1. returning wordEndIndex
2. returning raw string, associated data and wordEndIndex

Update README's description